### PR TITLE
Propose swap view

### DIFF
--- a/users/tests/test_propose_swap_view.py
+++ b/users/tests/test_propose_swap_view.py
@@ -1,0 +1,33 @@
+from django.core.urlresolvers import reverse
+from django.test import RequestFactory
+from django.test import TestCase
+import json
+
+from users.models import PairProposal
+from users.tests.factories import UserFactory
+from users.views import propose_swap
+
+HTTP_OK = 200
+
+
+class TestProposeSwapView(TestCase):
+    def setUp(self):
+        super(TestProposeSwapView, self).setUp()
+        self.request = RequestFactory()
+
+    def test_success(self):
+        user = UserFactory.create()
+        match = UserFactory.create()
+        user.profile.friends.add(match.profile)
+        request = self.request.post(
+            reverse('users:propose_swap'),
+            {'to_profile': match.profile.id})
+        request.user = user
+        self.assertFalse(PairProposal.objects.all())
+        response = propose_swap(request)
+        self.assertEqual(response.status_code, HTTP_OK)
+        self.assertEqual(response.content,
+                         json.dumps({'status': 'ok', 'errors': []}))
+        proposal = PairProposal.objects.get(from_profile=user.profile)
+        self.assertTrue(proposal)
+        self.assertEqual(proposal.to_profile, match.profile)

--- a/users/tests/test_propose_swap_view.py
+++ b/users/tests/test_propose_swap_view.py
@@ -27,7 +27,38 @@ class TestProposeSwapView(TestCase):
         response = propose_swap(request)
         self.assertEqual(response.status_code, HTTP_OK)
         self.assertEqual(response.content,
-                         json.dumps({'status': 'ok', 'errors': []}))
+                         json.dumps({'status': 'ok', 'errors': {}}))
         proposal = PairProposal.objects.get(from_profile=user.profile)
         self.assertTrue(proposal)
         self.assertEqual(proposal.to_profile, match.profile)
+
+    def test_get_fail(self):
+        user = UserFactory.create()
+        request = self.request.get(reverse('users:propose_swap'))
+        request.user = user
+        response = propose_swap(request)
+        self.assertEqual(response.status_code, HTTP_OK)
+        self.assertEqual(
+            response.content,
+            json.dumps(
+                {'status': 'error',
+                 'errors': {'method': 'Must POST with to_profile set'}}))
+
+    def test_invalid_error(self):
+        user = UserFactory.create()
+        match = UserFactory.create()
+        # Don't add match as a friend, so it's invalid
+        request = self.request.post(
+            reverse('users:propose_swap'),
+            {'to_profile': match.profile.id})
+        request.user = user
+        self.assertFalse(PairProposal.objects.all())
+        response = propose_swap(request)
+        self.assertEqual(response.status_code, HTTP_OK)
+        self.assertEqual(
+            response.content,
+            json.dumps(
+                {'status': 'error',
+                 'errors': {
+                     "to_profile": ["Select a valid choice. That choice is not one of the available choices."]}  # NOQA
+                }))

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,9 @@
 from django.conf.urls import url
 
 from users.views import profile
+from users.views import propose_swap
 
 urlpatterns = [
     url('^profile/$', profile, name='profile'),
+    url('^swap/$', propose_swap, name='propose_swap'),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -84,9 +84,10 @@ def propose_swap(request):
             from_profile=request.user.profile, data=request.POST)
         if form.is_valid():
             form.save()
-            return json_response({'status': 'ok', 'errors': []})
+            return json_response({'status': 'ok', 'errors': {}})
         else:
             return json_response({'status': 'error', 'errors': form.errors})
     else:
         return json_response(
-            {'status': 'error', 'errors': ['Must POST with to_profile set']})
+                {'status': 'error',
+                 'errors': {'method': 'Must POST with to_profile set'}})


### PR DESCRIPTION
Part of #16 

Adds a propose-swap json view at `/users/swap` that takes `{"to_profile": <int>}` as POST data.

@devinblais You can get that url by using `{% url "users:propose_swap" %}` in a template, eg:

`<a href="{% url "users:propose_swap" %}" type="button">...</a>`