### PR TITLE
Let the user accidentally click the Join now button without overwriting their profile

### DIFF
--- a/voteswap/templates/landing_page.html
+++ b/voteswap/templates/landing_page.html
@@ -28,7 +28,7 @@
       </p>
     </div>
     <div id="join" class="col-md-4 join-now">
-      <form class="form" method="POST" action="{% url "signup" %}">
+      <form class="form" method="POST" action="{% url "landing_page" %}">
         {% csrf_token %}
         {% bootstrap_form form size='large' %}
         {% buttons %}

--- a/voteswap/tests/test_landing_page.py
+++ b/voteswap/tests/test_landing_page.py
@@ -35,7 +35,7 @@ class TestLandingPageView(TestCase):
         response = landing_page(request)
         self.assertEqual(response.status_code, HTTP_OK)
         self.assertContains(response, 'Join with Facebook')
-        self.assertContains(response, 'action="%s"' % reverse('signup'))
+        self.assertContains(response, 'action="%s"' % reverse('landing_page'))
 
     def test_post(self):
         state = StateFactory()

--- a/voteswap/views.py
+++ b/voteswap/views.py
@@ -98,6 +98,12 @@ def confirm_signup(request):
         return HttpResponseRedirect(reverse('signup'))
     logger.info("Data in confirm_signup is %s" % data)
 
+    try:
+        if request.user.profile.fb_id:
+            # Skip sign up, they probably clicked "Join" on accident
+            return HttpResponseRedirect(reverse('users:profile'))
+    except:
+        pass
     form = LandingPageForm(data=data)
     try:
         if form.is_valid():


### PR DESCRIPTION
Now "Join Now" works the same as login if they've already logged in before.