### PR TITLE
secure:always in app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -24,8 +24,10 @@ version: 1
 handlers:
 - url: /static
   static_dir: static/
+  secure: always
 - url: .*
   script: voteswap.wsgi.application
+  secure: always
 
 # Only pure Python libraries can be vendored
 # Python libraries that use C extensions can


### PR DESCRIPTION
Set up TLS via the admin console, and this should force TLS always