### PR TITLE
Limit matches to 10 people

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -117,7 +117,7 @@ class ProfileContext(object):
     @cached_property
     def good_potential_matches(self):
         return [FriendMatchContext(fm, self)
-                for fm in get_friend_matches(self.profile)]
+                for fm in get_friend_matches(self.profile)][:10]
 
 
 class PendingMatchContext(object):


### PR DESCRIPTION
Random matches will show too many potential matches, so limit to 10